### PR TITLE
Remove dump()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ $fruits = [
 $flatten_fruits = array_flatten($fruits);
 ```
 
-### `dump()`
-
-We've added the `VarDumper` module from Symfony to have a better `dump()` function (in replacement of `var_dump()`). It can do many things and ease your debug life, go [read the documentation](https://symfony.com/doc/current/components/var_dumper.html) to know more about it ;)
-
 ### `array.php`
 
 - `array_diff_strict (array $array1, array $array2) : array`: Strict diff between two arrays by comparing the values at the same index.

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "require": {
         "php": ">=7.4.0",
         "ext-curl": "*",
-        "ext-fileinfo": "*",
-        "symfony/var-dumper": "^5.0"
+        "ext-fileinfo": "*"
     },
     "autoload": {
         "psr-4" : {


### PR DESCRIPTION
`dump()` requires Symfony 5. Since, many folks can have a completely different version of Symfony, it would be impossible to install Funktions.

It is better to drop this function and let people use whatever they want.